### PR TITLE
migrating to mysql 8

### DIFF
--- a/module.modulemap
+++ b/module.modulemap
@@ -1,5 +1,5 @@
 module mysqlclient {
-    header "/usr/local/include/mysql/mysql.h"
+    header "mysql_osx.h"
     link "mysqlclient"
     export *
 }

--- a/mysql_osx.h
+++ b/mysql_osx.h
@@ -1,0 +1,9 @@
+#ifndef __PERFECT_MYSQL_OSX__
+#define __PERFECT_MYSQL_OSX__
+#include "/usr/local/include/mysql/mysql.h"
+
+#if LIBMYSQL_VERSION_ID > 80000
+typedef char my_bool;
+#endif
+
+#endif


### PR DESCRIPTION
Recently `brew upgrade mysql` causes a major version conflict. 
This PR is one of the essential patches to allow both versions.

Tested by both versions:
`brew switch mysql <version>`, where version is
- 5.7.21
- 8.0.11
